### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main", "mainv2"]
 
+permissions:
+  contents: read
+
 jobs:
   quality-checks:
     name: Lint & Security


### PR DESCRIPTION
Potential fix for [https://github.com/aryan4859/flagForge1/security/code-scanning/4](https://github.com/aryan4859/flagForge1/security/code-scanning/4)

To fix the problem, explicitly set the GITHUB_TOKEN permissions to the minimum required. These jobs only need to read the repository contents to check out code; they do not create or modify any GitHub resources. The simplest and safest fix is to add a workflow-level `permissions:` block with `contents: read`, which applies to all jobs that don’t override it. This both satisfies CodeQL’s recommendation and adheres to the principle of least privilege.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Add a `permissions:` section near the top of the workflow (for example after the `on:` block, before `jobs:`) with `contents: read`.
- No changes are required inside the jobs, and no additional imports or dependencies are needed.
- Existing behavior (linting, security audit, and build) will be preserved, since they only depend on code checkout and environment variables, not elevated GitHub permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
